### PR TITLE
bug fix in client documentation

### DIFF
--- a/client.html
+++ b/client.html
@@ -67,7 +67,7 @@ title: HTTP client
 {% highlight clojure %}
 (let [urls ["http://server.com/api/1" "http://server.com/api/2"
             "http://server.com/api/3"]
-      futures (dorun (map http/get urls))]
+      futures (doall (map http/get urls))]
   (doseq [f futures]
     ;; wait for server response concurrently
     (println (-> @f :opt :url) " status: " (:status @f))


### PR DESCRIPTION
the example in the section "Combined, concurrent requests,
handle results synchronously" contains an error:
dorun returns nil so we should use doall instead
