### PR TITLE
Fix typo in Server Deployment paragraph.

### DIFF
--- a/server.html
+++ b/server.html
@@ -203,9 +203,9 @@ Channel defines the following contract:
 
   <h3 class="anchor" id="deploy">Recommended server deployment</h3>
   <p>http-kit runs alone happily, handy for development and quick deployment.
-    Use reverse proxy like <a href="http://wiki.nginx.org/Main">Nginx</a>,
+    Use of a reverse proxy like <a href="http://wiki.nginx.org/Main">Nginx</a>,
     <a href="http://www.lighttpd.net/">Lighthttpd</a>, etc in serious production is encouraged.
-    They also be used to<a href="migration.html#https">add https support</a>.</p>
+    They can also be used to <a href="migration.html#https">add https support</a>.</p>
   <ul>
     <li>They are fast, heavily optimized for static contents.</li>
     <li>They can be configured to compress the content sent to browsers</li>


### PR DESCRIPTION
The sentence re: a reverse proxy adding HTTPS support has a typo in it; this fixes it.
