### PR TITLE
Fix a typo

### DIFF
--- a/server.html
+++ b/server.html
@@ -58,7 +58,7 @@ title: HTTP server
     (@server :timeout 100)
     (reset! server nil)))
 
-(defn -main [&args]
+(defn -main [& args]
   ;; The #' is useful when you want to hot-reload code
   ;; You may want to take a look: https://github.com/clojure/tools.namespace
   ;; and http://http-kit.org/migration.html#reload


### PR DESCRIPTION
`&` and `args` should be separated with space, otherwise it is be a symbol `&args` and `-main` function should receive one argument.